### PR TITLE
as of python3.2, escape is in html instead of cgi

### DIFF
--- a/html-vault
+++ b/html-vault
@@ -23,7 +23,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import hashlib, textwrap, sys, getpass, json, base64
-from cgi import escape
+from html import escape
 from Cryptodome.Cipher import AES
 from Cryptodome.Random import get_random_bytes
 


### PR DESCRIPTION
https://docs.python.org/3/library/html.html#html.escape